### PR TITLE
Update GoBuildSystem implementation and add extraArguments method

### DIFF
--- a/buildsystem/buildsystem.cpp
+++ b/buildsystem/buildsystem.cpp
@@ -58,6 +58,11 @@ QHash<QString,QString> GoBuildSystem::defines(KDevelop::ProjectBaseItem*) const
     return {};
 }
 
+QString GoBuildSystem::extraArguments(KDevelop::ProjectBaseItem*) const
+{
+    return {};
+}
+
 ProjectTargetItem* GoBuildSystem::createTarget(const QString& target, KDevelop::ProjectFolderItem *parent)
 {
     Q_UNUSED(target)

--- a/buildsystem/buildsystem.h
+++ b/buildsystem/buildsystem.h
@@ -31,6 +31,7 @@ public:
     KDevelop::Path::List includeDirectories(KDevelop::ProjectBaseItem*) const override;
     KDevelop::Path::List frameworkDirectories(KDevelop::ProjectBaseItem*) const override;
     QHash<QString,QString> defines(KDevelop::ProjectBaseItem*) const override;
+    QString extraArguments(KDevelop::ProjectBaseItem* item) const override;
     KDevelop::ProjectTargetItem* createTarget(const QString& target, KDevelop::ProjectFolderItem *parent) override;
     bool addFilesToTarget(const QList<KDevelop::ProjectFileItem*> &files, KDevelop::ProjectTargetItem *parent) override;
     bool removeTarget(KDevelop::ProjectTargetItem *target) override;


### PR DESCRIPTION
Fix build error by adding missing virtual method to GoBuildSystem
Corresponding kdevelop commit: git://anongit.kde.org/kdevelop@0c05bd55965fc6c0468022c935f140408b99151c